### PR TITLE
Add the seventh button ("Playstation Logo" in top left corner) to gamepad mode

### DIFF
--- a/udraw-driver.cpp
+++ b/udraw-driver.cpp
@@ -198,6 +198,7 @@ int main(int argc, char** argv)
 
       evdev.add_key(BTN_START);
       evdev.add_key(BTN_SELECT);
+      evdev.add_key(BTN_Z);
     }
     else if (opts.keyboard_mode)
     {
@@ -284,6 +285,7 @@ int main(int argc, char** argv)
 
            evdev.send(EV_KEY, BTN_START,  decoder.get_start());
            evdev.send(EV_KEY, BTN_SELECT, decoder.get_select());
+           evdev.send(EV_KEY, BTN_Z, decoder.get_guide());
 
            evdev.send(EV_SYN, SYN_REPORT, 0);
          }

--- a/udraw_decoder.hpp
+++ b/udraw_decoder.hpp
@@ -118,6 +118,7 @@ public:
 
   bool get_start() const { return m_data[1] & 1; }
   bool get_select() const { return m_data[1] & 2; }
+  bool get_guide() const { return m_data[1] & 0x10; }
 };
 
 


### PR DESCRIPTION
Thank you @grumbel for a very useful, albeit basic, driver for the inexpensive uDraw PS3 tablet. The code is easy to read (even for beginners like me) as well as short and succinct and therefore ideal for hacking.
The PS button (referred to in the source code as "guide") is missing from gamepad mode. This pull requests adds it so we can have seven instead of six.

Testing done: Compiles and works as intended (so far).