### PR TITLE
Fixing persistent activated left-click in tablet mode and update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
 
 before_install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
-  - if [ "$CXX" == "clang++" ]; then export CXX="clang++-4.0" CC="clang-4.0"; fi
+  - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.9" CC="clang-3.9"; fi
 
 script:
   - git clean -f

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ addons:
     - llvm-toolchain-precise
     packages:
     - build-essential
-    - clang-4.0
+    - clang-3.9
     - cmake
     - g++-4.9
     - libboost-dev

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/lispparser/sexp-cpp.svg?branch=master)](https://travis-ci.org/lispparser/sexp-cpp)
+[![Build Status](https://travis-ci.org/Grumbel/udraw.svg?branch=master)](https://travis-ci.org/Grumbel/udraw)
 
 uDraw PS3 Linux Driver
 ======================

--- a/udraw-driver.cpp
+++ b/udraw-driver.cpp
@@ -297,7 +297,7 @@ int main(int argc, char** argv)
              evdev.send(EV_ABS, ABS_PRESSURE, decoder.get_pressure());
              evdev.send(EV_KEY, BTN_TOOL_PEN, 1);
 
-             if (decoder.get_pressure() > 0)
+             if (decoder.get_pressure() > 5)
              {
                evdev.send(EV_KEY, BTN_TOUCH, 1);
              }


### PR DESCRIPTION
This is intended to fix issue: [Tablet mode: "Left click threshold" too low #4]
Plus, it is updating the travis configuration